### PR TITLE
broken link fix: update link to REACTO

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ See below for additional learning resources.
 
 ## Past Presentation Slides
 - [Big O Notation](https://docs.google.com/presentation/d/1q-yGw-ekqtHOtoCOCxXJIVUpfyg-5CGrX1tZs1PlO2U/edit?usp=sharing)
-- [REACTO](http://blog.fullstackacademy.com/post/85636127906/the-reacto-pattern-for-acing-technical-interviews)
+- [REACTO](https://www.fullstackacademy.com/blog/the-reacto-pattern-for-acing-technical-interviews)
 - [Preparing for the Technical Interview](https://docs.google.com/presentation/d/1YcBQ4_w2u5BoS86GDvosDQdwIvmfNhLQY7xIf_7MwTE/pub?start=false&loop=false&delayms=3000)
 
 ## Whiteboarding Problems


### PR DESCRIPTION
Previous link leads to a 404 page.  This pull requests updates the README with a new link.